### PR TITLE
rename 'cleare_console' to 'clear_console'

### DIFF
--- a/src/music_kraken_cli.py
+++ b/src/music_kraken_cli.py
@@ -97,7 +97,7 @@ def get_genre():
     return genre
 
 
-def cli(start_at: int = 0, only_lyrics: bool = False, cleare_console: bool = True):
+def cli(start_at: int = 0, only_lyrics: bool = False, clear_console: bool = True):
     if clear_console:
         clear_console()
 


### PR DESCRIPTION
Hi!
Came across your reddit comment and was intrigued. While skimming the code I think I've found a bug.

On `line 100` in `music_kraken_cli.py` the `cli` function looks like this:

```python
def cli(start_at: int = 0, only_lyrics: bool = False, cleare_console: bool = True):
    if clear_console:
        clear_console()
    ...
```

the argument being passed in has an additional 'e' in it. The if statement below now just checks if the function 'clear_console' exists opposed to checking the argument.